### PR TITLE
Make Track page requests outside of store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2458,21 +2458,6 @@
         "supports-color": "^5.3.0"
       }
     },
-    "character-entities": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
-    },
-    "character-entities-legacy": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
-    },
-    "character-reference-invalid": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
-    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -2586,17 +2571,6 @@
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
     },
-    "clipboard": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
-      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -2703,11 +2677,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "comma-separated-tokens": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "4.1.1",
@@ -3526,12 +3495,6 @@
       "requires": {
         "delaunator": "^4.0.0"
       }
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -4707,14 +4670,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "fault": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-      "requires": {
-        "format": "^0.2.0"
-      }
-    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -5091,11 +5046,6 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
-    "format": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -5387,15 +5337,6 @@
         }
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -5526,22 +5467,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hast-util-parse-selector": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
-      "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
-    },
-    "hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
-      "requires": {
-        "comma-separated-tokens": "^1.0.0",
-        "hast-util-parse-selector": "^2.0.0",
-        "property-information": "^5.0.0",
-        "space-separated-tokens": "^1.0.0"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -5553,11 +5478,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
-    },
-    "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
     },
     "history": {
       "version": "4.7.2",
@@ -6195,20 +6115,6 @@
         }
       }
     },
-    "is-alphabetical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
-    },
-    "is-alphanumerical": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-      "requires": {
-        "is-alphabetical": "^1.0.0",
-        "is-decimal": "^1.0.0"
-      }
-    },
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
@@ -6286,11 +6192,6 @@
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
       "dev": true
     },
-    "is-decimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
-    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -6340,11 +6241,6 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-hexadecimal": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-negative-zero": {
       "version": "2.0.0",
@@ -6734,15 +6630,6 @@
       "dev": true,
       "requires": {
         "tslib": "^1.10.0"
-      }
-    },
-    "lowlight": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
-      "requires": {
-        "fault": "^1.0.2",
-        "highlight.js": "~9.13.0"
       }
     },
     "lru-cache": {
@@ -7734,19 +7621,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "parse-entities": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-      "requires": {
-        "character-entities": "^1.0.0",
-        "character-entities-legacy": "^1.0.0",
-        "character-reference-invalid": "^1.0.0",
-        "is-alphanumerical": "^1.0.0",
-        "is-decimal": "^1.0.0",
-        "is-hexadecimal": "^1.0.0"
-      }
-    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -8514,14 +8388,6 @@
         "utila": "~0.4"
       }
     },
-    "prismjs": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -8573,14 +8439,6 @@
       "requires": {
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
-      }
-    },
-    "property-information": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
-      "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
-      "requires": {
-        "xtend": "^4.0.0"
       }
     },
     "proxy-addr": {
@@ -9009,18 +8867,6 @@
         "react-svg-core": "^3.0.3"
       }
     },
-    "react-syntax-highlighter": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
-      "integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
-      "requires": {
-        "@babel/runtime": "^7.3.1",
-        "highlight.js": "~9.13.0",
-        "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
-        "refractor": "^2.4.1"
-      }
-    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -9053,26 +8899,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
       "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
-    },
-    "refractor": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
-      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
-      "requires": {
-        "hastscript": "^5.0.0",
-        "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
-      },
-      "dependencies": {
-        "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
-        }
-      }
     },
     "regenerate": {
       "version": "1.4.1",
@@ -9486,12 +9312,6 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -10049,11 +9869,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
-    },
-    "space-separated-tokens": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
     },
     "spdy": {
       "version": "4.0.2",
@@ -10773,12 +10588,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
     "react-router-last-location": "2.0.1",
-    "react-syntax-highlighter": "11.0.2",
     "redux": "4.0.1",
     "redux-thunk": "2.3.0",
     "sass": "1.26.10"

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -45,7 +45,7 @@ export const DEFAULT_PAGE_STATE = {
     endDate: null
 };
 export const DEFAULT_TRACK_PAGE_STATE = {
-    request_id: '',
+    request_id: undefined,
     sort_by: 'date',
     sort_dir: 'desc'
 };

--- a/src/components/Track/Durations.js
+++ b/src/components/Track/Durations.js
@@ -4,7 +4,6 @@ import { Card, CardBody, CardHeader, Tooltip } from '@patternfly/react-core';
 import React, { useEffect, useRef, useState } from 'react';
 
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 
 const SUCCESS_STATUSES = ['success'];
 const ERROR_STATUSES = ['error', 'failed', 'processing_error'];
@@ -94,11 +93,8 @@ const Durations = ({ payloads, durations }) => {
 };
 
 Durations.propTypes = {
-    payloads: PropTypes.array,
-    durations: PropTypes.array
+    payloads: PropTypes.array.isRequired,
+    durations: PropTypes.array.isRequired
 };
 
-export default connect((state) => ({
-    payloads: state.data.payloads,
-    durations: state.data.durations
-}), undefined)(Durations);
+export default Durations;

--- a/src/components/Track/Track.js
+++ b/src/components/Track/Track.js
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import React, { useEffect, useRef, useState } from 'react';
 
+import API from '../../utilities/Api';
 import Durations from './Durations';
 import ExportsDropdown from '../ExportsDropdown';
 import OptionsContainer from '../OptionsContainer';
@@ -23,36 +24,63 @@ import TrackTable from './TrackTable';
 import { connect } from 'react-redux';
 import { usePolling } from '../../utilities/Common';
 
-const Track = ({ payloads, request_id, sort_by, sort_dir, getPayloads }) => {
+const Track = ({ request_id, sort_by, sort_dir, addNotification }) => {
     const [activeTabKey, setActiveTabKey] = useState(0);
+    const [payloads, setPayloads] = useState();
+    const [durations, setDurations] = useState();
+    const [loading, setLoading] = useState();
     const currPayloads = useRef();
     const retryCounter = useRef();
 
+    const getData = async (restartCounter = false) => {
+        const resp = await API.get(`${ConstantTypes.API_URL}/v1/payloads/${request_id}?sort_by=${sort_by}&sort_dir=${sort_dir}`);
+        if (resp.status === 200) {
+            const { data, duration } = resp.data;
+            if (!currPayloads?.current || JSON.stringify(data) !== JSON.stringify(currPayloads.current)) {
+                setPayloads(data);
+                setDurations(duration);
+                setLoading(data?.length > 0 ? 'fulfilled' : 'rejected');
+                currPayloads.current = data;
+                retryCounter.current = restartCounter ? 0 : retryCounter.current;
+            } else {
+                retryCounter.current += 1;
+            }
+        } else {
+            addNotification('danger', 'Error fetching data', `Request failed with status code ${resp.status}`);
+            setLoading('rejected');
+        }
+    };
+
     useEffect(() => {
-        request_id && getPayloads(`${ConstantTypes.API_URL}/v1/payloads/${request_id}?sort_by=${sort_by}&sort_dir=${sort_dir}`);
-        retryCounter.current = 0;
-    }, [request_id, sort_dir, sort_by, getPayloads]);
+        setLoading(request_id && 'pending');
+        currPayloads.current = undefined;
+        request_id && (async () => await getData(true))();
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currPayloads, request_id]);
+
+    useEffect(() => {
+        request_id && (async () => await getData())();
+    //eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [sort_by, sort_dir]);
 
     usePolling(() => {
         if ((!retryCounter.current || retryCounter.current < 10) && payloads && request_id) {
             retryCounter.current = retryCounter.current || 0;
-            retryCounter.current = JSON.stringify(currPayloads.current) !== JSON.stringify(payloads) ? 0 : retryCounter.current + 1;
-            currPayloads.current = payloads;
-            getPayloads(`${ConstantTypes.API_URL}/v1/payloads/${request_id}?sort_by=${sort_by}&sort_dir=${sort_dir}`);
+            (async () => await getData(true))();
         }
     }, 2000);
 
     return <PageSection>
-        <TrackSearchBar/>
+        <TrackSearchBar loading={loading} payloads={payloads}/>
         {request_id && payloads?.length > 0 && <React.Fragment>
-            <Durations/>
+            {durations && <Durations durations={durations} payloads={payloads}/>}
             <Tabs activeKey={activeTabKey} onSelect={ (e, index) => setActiveTabKey(index) }>
                 <Tab eventKey={0} title='Status'>
                     <Card>
                         <CardHeader>
                         </CardHeader>
                         <CardBody>
-                            <TrackGraphic/>
+                            <TrackGraphic payloads={payloads}/>
                         </CardBody>
                     </Card>
                 </Tab>
@@ -69,7 +97,7 @@ const Track = ({ payloads, request_id, sort_by, sort_dir, getPayloads }) => {
                             </Flex>
                         </CardHeader>
                         <CardBody>
-                            <TrackTable/>
+                            <TrackTable payloads={payloads}/>
                         </CardBody>
                     </Card>
                 </Tab>
@@ -79,18 +107,16 @@ const Track = ({ payloads, request_id, sort_by, sort_dir, getPayloads }) => {
 };
 
 Track.propTypes = {
-    payloads: PropTypes.array,
     request_id: PropTypes.any,
     sort_by: PropTypes.string,
     sort_dir: PropTypes.string,
-    getPayloads: PropTypes.func
+    addNotification: PropTypes.func
 };
 
 export default connect((state) => ({
     request_id: state.track.request_id,
     sort_by: state.track.sort_by,
-    sort_dir: state.track.sort_dir,
-    payloads: state.data.payloads
+    sort_dir: state.track.sort_dir
 }), (dispatch) => ({
-    getPayloads: (url) => dispatch(AppActions.getPayloadTrack(url))
+    addNotification: (type, title, content) => dispatch(AppActions.addMessage(type, title, content))
 }))(Track);

--- a/src/components/Track/TrackGraphic.js
+++ b/src/components/Track/TrackGraphic.js
@@ -2,6 +2,8 @@ import {
     AccordionContent,
     AccordionItem,
     AccordionToggle,
+    ClipboardCopy,
+    ClipboardCopyVariant,
     Progress,
     ProgressMeasureLocation,
     ProgressVariant
@@ -17,7 +19,6 @@ import {
 
 import DateTime from 'luxon/src/datetime';
 import PropTypes from 'prop-types';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { getLocalDate } from '../../utilities/Common';
 
 const TrackGraphic = ({ service, source, statuses, messages }) => {
@@ -30,6 +31,7 @@ const TrackGraphic = ({ service, source, statuses, messages }) => {
 
     const generateRows = useCallback((messages) => {
         return messages.flatMap((message, index) => {
+            message.status === 'error' && toggleOpen(true);
             return [
                 {
                     cells: [
@@ -38,7 +40,7 @@ const TrackGraphic = ({ service, source, statuses, messages }) => {
                         },
                         {
                             title: message.message ? truncateString(message.message, 80) : '',
-                            props: { isOpen: false, ariaControls: 'compound-expansion-table-1' }
+                            props: { isOpen: message.message?.length > 0, ariaControls: 'compound-expansion-table-1' }
                         },
                         {
                             title: getLocalDate(
@@ -54,9 +56,9 @@ const TrackGraphic = ({ service, source, statuses, messages }) => {
                     compoundParent: 1,
                     cells: [
                         {
-                            title: <SyntaxHighlighter language='python'>
+                            title: <ClipboardCopy isCode isReadOnly isExpanded variant={ClipboardCopyVariant.expansion}>
                                 {message.message}
-                            </SyntaxHighlighter>,
+                            </ClipboardCopy>,
                             props: { colSpan: 6, className: 'pf-m-no-padding' }
                         }
                     ]

--- a/src/components/Track/TrackGraphicView.js
+++ b/src/components/Track/TrackGraphicView.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 import { Accordion } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import TrackGraphic from './TrackGraphic';
-import { connect } from 'react-redux';
 
 const TrackGraphicView = ({ payloads }) => {
 
@@ -64,11 +63,7 @@ const TrackGraphicView = ({ payloads }) => {
 };
 
 TrackGraphicView.propTypes = {
-    payloads: PropTypes.array
+    payloads: PropTypes.array.isRequired
 };
 
-const mapStateToProps = state => ({
-    payloads: state.data.payloads
-});
-
-export default connect(mapStateToProps, null)(TrackGraphicView);
+export default TrackGraphicView;

--- a/src/components/Track/TrackSearchBar.js
+++ b/src/components/Track/TrackSearchBar.js
@@ -10,6 +10,7 @@ import {
     EmptyStateBody,
     EmptyStateIcon,
     EmptyStateVariant,
+    Spinner,
     Text,
     TextContent,
     TextInput,
@@ -72,7 +73,12 @@ const TrackSearchBar = ({ push, request_id, payloads, loading, setRequestID }) =
             </Text>
         </TextContent>
         <Card className='pt-c-track__header'>
-            {request_id && payloads.length > 0 ? <div className='pt-c-track__header--content'>
+            {loading === 'pending' && <div className='pt-c-track__header--content'>
+                <Bullseye>
+                    <Spinner size='xl'/>
+                </Bullseye>
+            </div>}
+            {loading === 'fulfilled' && <div className='pt-c-track__header--content'>
                 <div className='pt-c-track__header--item'>
                     <span className='pt-c-track__header--title'> request_id: </span>
                     <span> {request_id} </span>
@@ -109,7 +115,8 @@ const TrackSearchBar = ({ push, request_id, payloads, loading, setRequestID }) =
                         </Button>
                     </div>
                 </div>}
-            </div> : !loading && <Bullseye>
+            </div>}
+            {(!loading || loading === 'rejected') && <Bullseye>
                 <EmptyState variant={EmptyStateVariant.lg}>
                     <EmptyStateIcon icon={TimesCircleIcon} color='#c9190b'/>
                     {request_id ? <Title headingLevel='h1'>
@@ -129,15 +136,13 @@ const TrackSearchBar = ({ push, request_id, payloads, loading, setRequestID }) =
 TrackSearchBar.propTypes = {
     push: PropTypes.func,
     request_id: PropTypes.string,
-    payloads: PropTypes.array,
-    loading: PropTypes.bool,
+    payloads: PropTypes.array.isRequired,
+    loading: PropTypes.bool.isRequired,
     setRequestID: PropTypes.func
 };
 
 const mapStateToProps = state => ({
-    request_id: state.track.request_id,
-    payloads: state.data.payloads,
-    loading: state.data.loading
+    request_id: state.track.request_id
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Track/TrackTable.js
+++ b/src/components/Track/TrackTable.js
@@ -68,7 +68,7 @@ const TrackTable = ({ payloads, cells, sortBy, sortDir, setTrackSortBy, setTrack
 };
 
 TrackTable.propTypes = {
-    payloads: PropTypes.array,
+    payloads: PropTypes.array.isRequired,
     cells: PropTypes.array,
     sortBy: PropTypes.string,
     sortDir: PropTypes.string,
@@ -77,7 +77,6 @@ TrackTable.propTypes = {
 };
 
 export default connect((state) => ({
-    payloads: state.data.payloads,
     cells: state.cell.cells,
     sortBy: state.track.sort_by,
     sortDir: state.track.sort_dir

--- a/src/utilities/Api.js
+++ b/src/utilities/Api.js
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+// only including GET here, since the API only supports GET
+export default {
+    get(url, headers = {}, params = {}) {
+        return axios.get(url, {
+            headers,
+            params
+        });
+    }
+};


### PR DESCRIPTION
Adds the following:

1. Api file to the utilities directory
2. Removes `react-syntax-highlighter` in favor of patternfly equivalent
3. Uses Api util in Track component to manage `payloads` and `durations` within track page
4. Sets payloads with status `error` open by default