### PR TITLE
Enable local development with proxy to stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+- [Payload Tracker Frontend](#payload-tracker-frontend)
+  - [Overview](#overview)
+  - [Architecture](#architecture)
+  - [Routes](#routes)
+  - [Basic Usage](#basic-usage)
+  - [Docker](#docker)
+  - [Prequisites](#prequisites)
+  - [Dev Setup](#dev-setup)
+  - [Dev Setup with proxy](#dev-setup-with-proxy)
+  - [Dev Setup using Docker](#dev-setup-using-docker)
+  - [Contributing](#contributing)
+  - [Versioning](#versioning)
+
 Payload Tracker Frontend
 ===========================================
 
@@ -66,8 +79,36 @@ pipenv run server
 npm run start
 ```
 
-**Note:** This will yield CORS errors. Consider installinig https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf to remove these errors. 
+**Note:** This will yield CORS errors. Consider installinig https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf to remove these errors.
 
+Dev Setup with proxy
+--------------------
+
+This option will run the frontend application connected to stage backend, so there is no need to run the backend service locally.
+
+1. Install dependencies
+```
+npm i
+```
+
+2. Go to the stage frontend, login with your GitHub credentials, then open Developer tools (F12), go to application tab > cookies > domain and find `_ouath_proxy` cookie. Copy its value.
+
+3. Start Frontend with proxy enabled
+```
+npm run start:proxy
+```
+
+4. Open local frontend on: `https://localhost:3000`
+
+5. Open JavaScript console (F12)
+
+6. Insert your copied cookie from step #2 (replace `<COPIEDVALUE>`).
+
+```js
+document.cookie = "_oauth_proxy=<COPIEDVALUE>"
+```
+
+7. Refresh the page
 
 Dev Setup using Docker
 --------------------

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "postbuild": "node dr-surge.js",
     "build": "ENV=production webpack --mode production --config webpack.config.js",
     "start": "ENV=development webpack serve --mode development --config webpack.config.js",
+    "start:proxy": "ENV=development PROXY=true webpack serve --mode development --config webpack.config.js",
     "lint": "eslint --ext .js ./src/",
     "analyze": "ANALYZE=true npm run build",
     "clean": "rimraf dist"

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -1,6 +1,6 @@
 import { sortable } from '@patternfly/react-table';
 
-export const API_URL = process.env.ENV === 'development' ? 'http://localhost:8080' : '';
+export const API_URL = process.env.ENV === 'development' && !process.env.PROXY ? 'http://localhost:8080' : '';
 
 export const SET_CELL_ACTIVITY = 'SET_CELL_ACTIVITY';
 export const TOGGLE_NAV = 'TOGGLE_NAV';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,13 +40,21 @@ module.exports = {
         }
     },
     devServer: {
-        https: false,
+        https: Boolean(process.env.PROXY),
         allowedHosts: 'all',
         port: process.env.PORT || 3000,
         historyApiFallback: true,
         client: {
             overlay: false
-        }
+        },
+        ...(process.env.PROXY && { proxy: {
+            '/api': {
+                target: 'https://payload-tracker-frontend-payload-tracker-stage.apps.crcs02ue1.urby.p1.openshiftapps.com/',
+                changeOrigin: true,
+                autoRewrite: true,
+                secure: true
+            }
+        } })
     },
     module: {
         rules: [
@@ -72,7 +80,7 @@ module.exports = {
     },
     plugins: [
         new HtmlWebpackPlugin({ template: './src/index.html' }),
-        new EnvironmentPlugin({ ENV: '' }),
+        new EnvironmentPlugin({ ENV: '', PROXY: '' }),
         ...(process.env.ANALYZE === 'true' ? [new BundleAnalyzerPlugin()] : [])
     ]
 };


### PR DESCRIPTION
Dev Setup with proxy
--------------------

This option will run the frontend application connected to stage backend, so there is no need to run the backend service locally.

1. Install dependencies
```
npm i
```

2. Go to the stage frontend, login with your GitHub credentials, then open Developer tools (F12), go to application tab > cookies > domain and find `_ouath_proxy` cookie. Copy its value.

3. Start Frontend with proxy enabled
```
npm run start:proxy
```

4. Open local frontend on: `https://localhost:3000`

5. Open JavaScript console (F12)

6. Insert your copied cookie from step #2 (replace `<COPIEDVALUE>`).

```js
document.cookie = "_oauth_proxy=<COPIEDVALUE>"
```

7. Refresh the page