### PR TITLE
Add . to pathing for NGINX pathing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -44,7 +44,7 @@ http {
              #proxy_set_header Host $host;
              #proxy_cache_bypass $http_upgrade;
         }
-        location / {
+        location ./ {
             try_files $uri /index.html;
         }
     }


### PR DESCRIPTION
Add . to pathing for NGINX pathing, this is a quick fix for some pathing issues we've been having with Payload-trackers integration with Turnpike.