### PR TITLE
Fix archive link environment check

### DIFF
--- a/src/components/Track/TrackSearchBar.js
+++ b/src/components/Track/TrackSearchBar.js
@@ -51,7 +51,8 @@ const TrackSearchBar = ({ payloads, loading }) => {
         .then(
             resp => {
                 let archiveDownloadLink = resp.data.url;
-                if (process.env.ENV) {
+                if (process.env.ENV === 'development') {
+                    // In development, local minio provides the url to the archive in place of s3
                     archiveDownloadLink = 'http://localhost' + archiveDownloadLink.substring(archiveDownloadLink.indexOf(':9000'));
                 }
 


### PR DESCRIPTION
## What?
Remove the alterations to the URL used in local development

## Why?
Allows the correct URL to be returned in PROD and STAGE

## How?
Updated the check of the ENV environment variable