### PR TITLE
Correctly set request_id from url param

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,7 @@ const App = () => {
             <Route path='/app/payload-tracker/payloads' component={Payloads}/>
             <Route path='/app/payload-tracker/statuses' component={Statuses}/>
             <Route exact path='/app/payload-tracker/track' component={Track}/>
-            <Route path='/app/payload-tracker/track/:request_id' component={Track}/>
+            <Route path='/app/payload-tracker/track/:url_req_id' component={Track}/>
         </Switch>
     </Page>;
 

--- a/src/components/Track/Track.js
+++ b/src/components/Track/Track.js
@@ -12,6 +12,7 @@ import {
     Tabs
 } from '@patternfly/react-core';
 import React, { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import API from '../../utilities/Api';
 import Durations from './Durations';
@@ -28,6 +29,8 @@ const Track = () => {
     const sort_by = useSelector(state => state.track.sort_by);
     const sort_dir = useSelector(state => state.track.sort_dir);
     const dispatch = useDispatch();
+
+    const { url_req_id } = useParams();
 
     const [activeTabKey, setActiveTabKey] = useState(0);
     const [payloads, setPayloads] = useState();
@@ -63,6 +66,8 @@ const Track = () => {
     };
 
     useEffect(() => {
+        url_req_id && dispatch(AppActions.setTrackRequestID(url_req_id));
+
         setLoading(request_id && 'pending');
         currPayloads.current = undefined;
         request_id && (async () => await getData(true))();


### PR DESCRIPTION
Previously, we weren't fetching the request_id from the url param. This PR correctly fetches the request id from the url and dispatches a redux action to record the fetched request_id in the app state.