### PR TITLE
Use query paramers for request_id in the track endpoint

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,6 @@ const App = () => {
             <Route path='/app/payload-tracker/payloads' component={Payloads}/>
             <Route path='/app/payload-tracker/statuses' component={Statuses}/>
             <Route exact path='/app/payload-tracker/track' component={Track}/>
-            <Route path='/app/payload-tracker/track/:url_req_id' component={Track}/>
         </Switch>
     </Page>;
 

--- a/src/components/HoverableAttribute.js
+++ b/src/components/HoverableAttribute.js
@@ -17,7 +17,7 @@ const HoverableAttribute = ({ type, filter, value }) => {
     const clickHandler = ()  => {
         if (type === 'track') {
             dispatch(AppActions.setTrackRequestID(value));
-            dispatch(push(`/app/payload-tracker/track/${value}`));
+            dispatch(push(`/app/payload-tracker/track?request_id=${value}`));
         } else if (type === 'filter') {
             dispatch(AppActions.stageFilters({ [filter]: value }));
         } else { return null; }

--- a/src/components/Track/Track.js
+++ b/src/components/Track/Track.js
@@ -12,7 +12,7 @@ import {
     Tabs
 } from '@patternfly/react-core';
 import React, { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 import API from '../../utilities/Api';
 import Durations from './Durations';
@@ -22,15 +22,16 @@ import TrackGraphic from './TrackGraphicView';
 import TrackSearchBar from './TrackSearchBar';
 import TrackTable from './TrackTable';
 import { useDispatch, useSelector } from 'react-redux';
-import { usePolling } from '../../utilities/Common';
+import { usePolling, getValueFromURL, validUUID } from '../../utilities/Common';
 
 const Track = () => {
+    const location = useLocation();
+    const queryReqId = getValueFromURL(location, 'request_id') || null;
+
     const request_id = useSelector(state => state.track.request_id);
     const sort_by = useSelector(state => state.track.sort_by);
     const sort_dir = useSelector(state => state.track.sort_dir);
     const dispatch = useDispatch();
-
-    const { url_req_id } = useParams();
 
     const [activeTabKey, setActiveTabKey] = useState(0);
     const [payloads, setPayloads] = useState();
@@ -66,7 +67,9 @@ const Track = () => {
     };
 
     useEffect(() => {
-        url_req_id && dispatch(AppActions.setTrackRequestID(url_req_id));
+        if (queryReqId !== null && validUUID(queryReqId)) {
+            queryReqId && dispatch(AppActions.setTrackRequestID(queryReqId));
+        }
 
         setLoading(request_id && 'pending');
         currPayloads.current = undefined;

--- a/src/components/Track/TrackSearchBar.js
+++ b/src/components/Track/TrackSearchBar.js
@@ -81,7 +81,10 @@ const TrackSearchBar = ({ payloads, loading }) => {
             />
             <Button
                 variant='primary'
-                onClick={() => dispatch(AppActions.setTrackRequestID(id))}
+                onClick={() => {
+                    dispatch(AppActions.setTrackRequestID(id));
+                    dispatch(push(`/app/payload-tracker/track?request_id=${id}`));
+                }}
                 isDisabled={id === ''}>
                     Submit
             </Button>

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <title>Payload Tracker</title>
-    <base href="/" />
     <link rel="icon" type="image/png" href="https://access.redhat.com/webassets/avalon/g/favicon.ico">
   </head>
   <body>

--- a/src/middlewares/urlSync.js
+++ b/src/middlewares/urlSync.js
@@ -12,11 +12,6 @@ export default store => next => action => {
 
     const updateSearch = (search) => {
         switch (type) {
-            case ConstantTypes.SET_TRACK_REQUEST_ID:
-                store.dispatch(replace({
-                    pathname: `/app/payload-tracker/track/${action.payload}`
-                }));
-                return;
             case ConstantTypes.SET_TRACK_SORT_DIR:
                 return {
                     ...search,

--- a/src/utilities/Common.js
+++ b/src/utilities/Common.js
@@ -49,3 +49,14 @@ export const usePolling = (callback, delay) => {
         }
     }, [callback, delay]);
 };
+
+export const validUUID = (str) => {
+    const uuidStr = '' + str;
+
+    const uuidMatch = uuidStr.match('^[0-9a-fA-F]{32}$');
+    if (uuidMatch === null) {
+        return false;
+    }
+
+    return true;
+};


### PR DESCRIPTION
We are switching to the `/track?request_id=<uuid>` url format for the track endpoint, this should resolve the webpack/ngix page serving issue we are facing. Also, imo, this new verbose url format is quite nice.