### PR TITLE
Fix missing data before page refresh [RHCLOUD-19421]

### DIFF
--- a/src/components/OptionsContainer.js
+++ b/src/components/OptionsContainer.js
@@ -49,7 +49,7 @@ const OptionsContainer = ({ isDisabled }) => {
             toggleTemplate={<React.Fragment>Show Columns</React.Fragment>}
         />}
         isOpen={isOpen}
-        isDisabled={isDisabled}
+        isdisabled={isDisabled}
     />;
 };
 

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -99,6 +99,7 @@ const PayloadsTable = ({ sortDir, setSortDir, sortBy, setSortBy }) => {
                 direction: sortDir
             }}
             onSort={(e, index, direction) => onSort(e, formattedCells[index].title, direction)}
+            aria-label='Payloads Table'
         >
             <TableHeader/>
             <TableBody/>

--- a/src/reducers/CellReducer.js
+++ b/src/reducers/CellReducer.js
@@ -29,7 +29,7 @@ const CellReducer = (state = initialState, action) => {
         case LOCATION_CHANGE:
             return action.payload.location.pathname === state.cellPath ? state : {
                 ...state,
-                cells: action.payload.location.pathname === '/payloads' ?
+                cells: action.payload.location.pathname === '/app/payload-tracker/payloads' ?
                     ConstantTypes.DEFAULT_PAYLOAD_CELL_STATE :
                     ConstantTypes.DEFAULT_STATUSES_CELL_STATE,
                 cellPath: action.payload.location.pathname


### PR DESCRIPTION
Fixed misaligned/missing data in the payloads table requiring a refresh.

**Before:**
![image](https://user-images.githubusercontent.com/39098327/185477424-19c1043e-896c-4001-9af2-923ae07b9b98.png)
**After:**
![image](https://user-images.githubusercontent.com/39098327/185477584-7a5a7827-ba07-494d-91a5-5e4d6f625db0.png)
