### PR TITLE
remove unused packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@patternfly/react-table": "4.67.19",
     "axios": "0.26.1",
     "connected-react-router": "6.9.2",
-    "env-cmd": "^10.1.0",
     "history": "4.7.2",
     "luxon": "1.24.1",
     "react": "17.0.2",
@@ -28,7 +27,6 @@
     "react-redux": "7.2.6",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
-    "react-scripts": "^5.0.1",
     "redux": "4.1.2",
     "redux-thunk": "2.4.1",
     "sass": "1.49.10"


### PR DESCRIPTION
Remove unused `env-cmd` and `react-scripts` packages causing build to fail