### PR TITLE
Remove old minio formatting for local dev [RHCLOUD-21125]

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,50 +118,6 @@ npm run build
 docker build . -f Dockerfile-dev -t frontend:latest && docker run -p 8080:8080 frontend:latest
 ```
 
-Dev Testing
---------------------
-With the Payload Tracker Service and frontend running locally, most of the frontend's features are available. Populate the DB using the Payload Tracker Service make commands <http://github.com/RedHatInsights/payload-tracker-go#development>.
-
-### Archive Download
-
-Using Ingress, you can download a payload archive from this app. To test functionality locally:
-
-1. Make a Jenkins build of the Payload Tracker Service, or use one created with a recent PR Build.
-
-2. Login to ephemeral with the OpenShift Client. Login token can be found on the ephemeral OpenShift website.
-
-3. Deploy an ephemeral environment with [Bonfire](https://github.com/RedHatInsights/bonfire).
-```#!/bin/bash
-# Fill in the desired commit and PR references.
-bonfire deploy payload-tracker --source=appsre --ref-env insights-stage --set-template-ref payload-tracker-go={commit-ref} --set-image-tag quay.io/cloudservices/payload-tracker-go={pr-ref} --timeout 900 --optional-deps-method hybrid --single-replicas -d 2h
-```
-
-4. Switch to your ephemeral environment.
-```#!/bin/bash
-oc project {namespace}
-```
-
-5. Port forward the minio, ingress, and payload-tracker-api pods.
-```#!/bin/bash
-oc port-forward {minio-pod} 9000:9000 # ephemeral to local 9000
-oc port-forward {ingress-pod} 8000:8000 # ephemeral to local 8000
-oc port-forward {payload-tracker-api-pod} 8080:8000 # ephemeral 8000 to local 8080
-```
-
-6. Start Payload Tracker frontend locally as in [Dev Setup](#dev-setup).
-
-7. Download this [sample archive](https://github.com/RedHatInsights/insights-puptoo/tree/master/dev/test-archives) into your working directory.
-
-8. Curl the sample archive to the ingress pod. The ```x-rh-identity``` header requires access to archive downloads with the associate role ```platform-archive-download```. The header provided below has this role.
-```#!/bin/bash
-curl -F "file=@core-base.tar.gz;type=application/vnd.redhat.advisor.somefile+tgz" -H "x-rh-identity: eyJpZGVudGl0eSI6eyJhc3NvY2lhdGUiOnsiUm9sZSI6WyJwbGF0Zm9ybS1hcmNoaXZlLWRvd25sb2FkIl19LCJhdXRoX3R5cGUiOiJzYW1sLWF1dGgiLCJ0eXBlIjoiQXNzb2NpYXRlIn19" -H "x-rh-insights-request-id: 25a5f716d2f211ec9d640242ac120002" http://localhost:8000/api/ingress/v1/upload
-```
-
-9. Next, add an extension to your browser to modify the request header. The [ModHeader extension](https://modheader.com/) is easy-to-use. Then, use that extension to append the ```x-rh-identity```.
-
-10. Navigate to the ```Payloads``` page on <http://localhost:3000/app/payload-tracker/payloads>, and click the request_id. Finally, download the uploaded archive!
-
-
 Contributing
 --------------------
 All outstanding issues or feature requests should be filed as Issues on this Github

--- a/src/AppConstants.js
+++ b/src/AppConstants.js
@@ -1,6 +1,6 @@
 import { sortable } from '@patternfly/react-table';
 
-export const API_URL = process.env.ENV === 'development' ? 'http://localhost:8080' : '/app/payload-tracker';
+export const API_URL = process.env.ENV === 'development' ? 'http://localhost:8080/app/payload-tracker' : '/app/payload-tracker';
 
 export const SET_CELL_ACTIVITY = 'SET_CELL_ACTIVITY';
 export const TOGGLE_NAV = 'TOGGLE_NAV';

--- a/src/components/Track/TrackSearchBar.js
+++ b/src/components/Track/TrackSearchBar.js
@@ -52,11 +52,6 @@ const TrackSearchBar = ({ payloads, loading }) => {
         .then(
             resp => {
                 let archiveDownloadLink = resp.data.url;
-                if (process.env.ENV === 'development') {
-                    // In development, local minio provides the url to the archive in place of s3
-                    archiveDownloadLink = 'http://localhost' + archiveDownloadLink.substring(archiveDownloadLink.indexOf(':9000'));
-                }
-
                 window.open(archiveDownloadLink, '_blank');
             }
         );


### PR DESCRIPTION
Remove old conditional formatting of the archive URL, which is breaking the new mock archive link for local development.