### PR TITLE
Remove filter button jittering on mouseover [RHCLOUD-21124]

### DIFF
--- a/src/components/HoverableAttribute.js
+++ b/src/components/HoverableAttribute.js
@@ -31,7 +31,8 @@ const HoverableAttribute = ({ type, filter, value }) => {
                 onMouseOver={ () => setHover(true) }
                 onMouseOut={ () => setHover(false) }
             >
-                {truncateString(value, 12)} {isHovered ? <PlusCircleIcon/> : null }
+                {truncateString(value, 12)}
+                {<PlusCircleIcon visibility={isHovered ? 'visible' : 'hidden'} />}
             </Button>
         </Tooltip> : <Button
             onClick={clickHandler}
@@ -39,7 +40,8 @@ const HoverableAttribute = ({ type, filter, value }) => {
             onMouseOver={ () => setHover(true) }
             onMouseOut={ () => setHover(false) }
         >
-            {value} {isHovered ? <PlusCircleIcon/> : null }
+            {value}
+            {<PlusCircleIcon visibility={isHovered ? 'visible' : 'hidden'} />}
         </Button>}
     </React.Fragment>;
 };


### PR DESCRIPTION
# What?
Remove the visual jittering when hovering over the filter icon for a field in the table.

# How?
Instead of only rendering the `<PlusCircleIcon />` when `isHovered` is true, always render it but only display it 
(`visibility: visible`) when hovered. This way, the icon's space is preserved and there is no flickering.