### PR TITLE
Notify user when no archive is found [RHCLOUD-21271]

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -85,6 +85,7 @@ objects:
         - name: quay-cloudservices-pull
         - name: rh-registry-pull
         restartPolicy: Always
+        serviceAccountName: payload-tracker-frontend
         schedulerName: default-scheduler
         securityContext: {}
         terminationGracePeriodSeconds: 30

--- a/src/components/Track/TrackSearchBar.js
+++ b/src/components/Track/TrackSearchBar.js
@@ -54,6 +54,24 @@ const TrackSearchBar = ({ payloads, loading }) => {
                 let archiveDownloadLink = resp.data.url;
                 window.open(archiveDownloadLink, '_blank');
             }
+        )
+        .catch(
+            error => {
+                if (error.response && error.response.status === 404) {
+                    dispatch(AppActions.addMessage(
+                        'danger',
+                        'No archive found for this request',
+                        'Your payload was not stored by Ingress or it\'s 24-hour expiry has passed.'
+                    ));
+                    return;
+                }
+
+                dispatch(AppActions.addMessage(
+                    'danger',
+                    'Error retrieving archive link',
+                    error.message
+                ));
+            }
         );
     };
 


### PR DESCRIPTION
Adds a pop-up message to let the user know if the archive they're trying to download is unavailable.
[RHCLOUD-21271](https://issues.redhat.com/browse/RHCLOUD-21271)
![No Archive Found](https://user-images.githubusercontent.com/39098327/192613663-fdf881dd-36f5-419c-8f50-cee9f2b8d0f6.gif)