### PR TITLE
Update number of default replicas to 3

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -123,7 +123,7 @@ parameters:
   value: 512Mi
 - description: The number of replicas to use for the prometheus deployment
   name: REPLICAS
-  value: '1'
+  value: '3'
 - description: Image tag
   name: IMAGE_TAG
   required: true


### PR DESCRIPTION
Update the number of default replicas for payload-tracker to 3 to satisfy the app-sre bot.