### PR TITLE
task: remove service serviceAccountName

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -86,7 +86,6 @@ objects:
         - name: quay-cloudservices-pull
         - name: rh-registry-pull
         restartPolicy: Always
-        serviceAccountName: payload-tracker-frontend
         schedulerName: default-scheduler
         securityContext: {}
         terminationGracePeriodSeconds: 30


### PR DESCRIPTION
We needed this back when we were running the openshift-oauth pod. Now that we're coming through turnpike to get to the frontend, we're authenticated there. No more sidecare. Let's get rid of this config

Signed-off-by: Stephen Adams <tsadams@gmail.com>