### PR TITLE
Fix: Make timestamps in track page more readable 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "0.26.1",
     "connected-react-router": "6.9.2",
     "history": "4.7.2",
+    "humanize-duration": "3.28.0",
     "luxon": "1.24.1",
     "react": "17.0.2",
     "react-csv": "1.1.1",

--- a/src/components/Track/Durations.js
+++ b/src/components/Track/Durations.js
@@ -12,7 +12,7 @@ const Durations = ({ payloads, durations }) => {
     const [width, setWidth] = useState();
     const [totalTime, setTotalTime] = useState();
     const chartRef = useRef();
-    const humanizeDuration = require("humanize-duration");
+    const humanizeDuration = require('humanize-duration');
     const contains = (value, arr) => arr.filter(item => item === value).length > 0;
     const checkStatus = (service, statuses) => payloads.filter(payload => {
         return payload.service === service && contains(payload.status, statuses);
@@ -24,7 +24,6 @@ const Durations = ({ payloads, durations }) => {
 
     const reverse = (str) => str.split('').reverse().join('');
 
-
     const getSeconds = (str) => {
         const time = reverse(str);
         const arr = time.split(':');
@@ -34,7 +33,7 @@ const Durations = ({ payloads, durations }) => {
 
     //Using the humanizeDuration package to label seconds in a more readable format
     const getReadableTime = (time) => {
-        return humanizeDuration(getSeconds(time), { units: ["d", "h", "m", "s", "ms"], round: false })
+        return humanizeDuration(getSeconds(time), { units: ['d', 'h', 'm', 's', 'ms'], round: false });
     };
 
     const isReadyToRender = () => Boolean(width && totalTime && getSeconds(durations?.total_time_in_services) !== 0);
@@ -55,7 +54,6 @@ const Durations = ({ payloads, durations }) => {
         //eslint-disable-next-line
     }, [durations, width]);
 
-
     return <Card className='pt-c-durations'>
         <CardHeader>
             <div className='pt-c-durations__header'>
@@ -70,7 +68,6 @@ const Durations = ({ payloads, durations }) => {
         </CardHeader>
         <CardBody>
             <div ref={chartRef} className={`pt-c-durations__chart ${!isReadyToRender() && 'hide'}`}>
-                
                 {isReadyToRender() && Object.entries(durations).map(([key, duration]) => {
                     const [service, source] = key.split(':');
                     if (!contains(service, ['total_time', 'total_time_in_services'])) {
@@ -79,8 +76,7 @@ const Durations = ({ payloads, durations }) => {
                                 className={`pt-c-durations__service ${getStatus(service)}`}
                             />
                         </Tooltip>;
-                    }
-                })}
+                    }})}
             </div>
             <div className='pt-c-durations__legend'>
                 {Object.entries(durations).map(([key, duration]) => {

--- a/src/components/Track/Durations.js
+++ b/src/components/Track/Durations.js
@@ -12,6 +12,7 @@ const Durations = ({ payloads, durations }) => {
     const [width, setWidth] = useState();
     const [totalTime, setTotalTime] = useState();
     const chartRef = useRef();
+    const humanizeDuration = require("humanize-duration"); //Dalia Testing
     const contains = (value, arr) => arr.filter(item => item === value).length > 0;
     const checkStatus = (service, statuses) => payloads.filter(payload => {
         return payload.service === service && contains(payload.status, statuses);
@@ -23,11 +24,17 @@ const Durations = ({ payloads, durations }) => {
 
     const reverse = (str) => str.split('').reverse().join('');
 
+
     const getSeconds = (str) => {
         const time = reverse(str);
         const arr = time.split(':');
         const timeArr = arr.map(timePart => parseFloat(reverse(timePart))).reverse();
         return (timeArr[0] * 3600) + (timeArr[1] * 60) + timeArr[2];
+    };
+
+    //Using the humanizeDuration package to label seconds in a more readable format
+    const getReadableTime = (time) => {
+        return humanizeDuration(getSeconds(time), { units: ["d", "h", "m", "s", "ms"], round: false })
     };
 
     const isReadyToRender = () => Boolean(width && totalTime && getSeconds(durations?.total_time_in_services) !== 0);
@@ -48,20 +55,22 @@ const Durations = ({ payloads, durations }) => {
         //eslint-disable-next-line
     }, [durations, width]);
 
+
     return <Card className='pt-c-durations'>
         <CardHeader>
             <div className='pt-c-durations__header'>
                 <span>
-                    {durations?.total_time && `Total Time: ${durations.total_time}`}
+                    {durations?.total_time && `Total Time: ${getReadableTime(durations.total_time)}`}
                 </span>
                 <span>
                     {durations?.total_time_in_services &&
-                        `Total Time in Services: ${durations.total_time_in_services}`}
+                        `Total Time in Services: ${getReadableTime(durations.total_time_in_services)}`}
                 </span>
             </div>
         </CardHeader>
         <CardBody>
             <div ref={chartRef} className={`pt-c-durations__chart ${!isReadyToRender() && 'hide'}`}>
+                
                 {isReadyToRender() && Object.entries(durations).map(([key, duration]) => {
                     const [service, source] = key.split(':');
                     if (!contains(service, ['total_time', 'total_time_in_services'])) {
@@ -81,8 +90,8 @@ const Durations = ({ payloads, durations }) => {
                             <div className={`pt-c-durations__legend--circle ${getStatus(service)}`}/>
                             <div className='pt-c-durations__legend--label'>
                                 {source !== 'undefined' ?
-                                    `${service} from ${source} | ${duration}` :
-                                    `${service} | ${duration}`}
+                                    `${service} from ${source} | ${getReadableTime(duration)}` :
+                                    `${service} | ${getReadableTime(duration)}`}
                             </div>
                         </div>;
                     }

--- a/src/components/Track/Durations.js
+++ b/src/components/Track/Durations.js
@@ -12,7 +12,7 @@ const Durations = ({ payloads, durations }) => {
     const [width, setWidth] = useState();
     const [totalTime, setTotalTime] = useState();
     const chartRef = useRef();
-    const humanizeDuration = require("humanize-duration"); //Dalia Testing
+    const humanizeDuration = require("humanize-duration");
     const contains = (value, arr) => arr.filter(item => item === value).length > 0;
     const checkStatus = (service, statuses) => payloads.filter(payload => {
         return payload.service === service && contains(payload.status, statuses);


### PR DESCRIPTION
What?
Adding package to make timestamp more readable.
https://issues.redhat.com/browse/RHCLOUD-21402

Why?
To make the timestamp in the Track page more readable. 
EX:
00:00:00.042076 to 0.04 ms
00:02:30.042076 to 2.3 m 

How?
Added package humanizeDuration (https://github.com/EvanHahn/HumanizeDuration.js)
Created a function to get the readable time: getting the seconds of the duration and calling the humanize duration package to add units to that time. 

Secure Coding Practices Checklist Link
https://github.com/RedHatInsights/secure-coding-checklist