### PR TITLE
RHCLOUD-25626 Uses regular font to display the message

### DIFF
--- a/src/components/Track/TrackGraphic.js
+++ b/src/components/Track/TrackGraphic.js
@@ -55,7 +55,7 @@ const TrackGraphic = ({ service, source, statuses, messages, requestId }) => {
                     compoundParent: 1,
                     cells: [
                         {
-                            title: <ClipboardCopy isCode isReadOnly isExpanded variant={ClipboardCopyVariant.expansion}>
+                            title: <ClipboardCopy isReadOnly isExpanded variant={ClipboardCopyVariant.expansion}>
                                 {message.message}
                             </ClipboardCopy>,
                             props: { colSpan: 6, className: 'pf-m-no-padding' }


### PR DESCRIPTION
This was an issue happening on google chrome - it didn't seem to affect firefox (or at least not that much).
Looks like using a monospaced font does something strange in chrome and the width calculations don't work well enough.

I tried updating to the latest minor version but that didn't work at all. So i decided to remove the `isCode` prop from the component to make it use a regular font.

Note that the page still requires a min width before it starts to collapse, but that's the whole page and not the component so didn't pursue any further fix for that. 

Before:
![screenshot_2024-04-10T14:11:23](https://github.com/RedHatInsights/payload-tracker-frontend/assets/3845764/3e015635-e452-42c1-a41c-a9de449fc892)

After:
![screenshot_2024-04-10T14:11:02](https://github.com/RedHatInsights/payload-tracker-frontend/assets/3845764/8a1f0f91-4c36-4137-9443-b7a2a786a5fa)
