### PR TITLE
fix(build_deploy): only create sc tag when building sc branch

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -67,12 +67,12 @@ main() {
     container_engine_cmd tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
 
     if ! _local_build; then
-        container_engine_cmd push "${IMAGE}:${IMAGE_TAG}"
 
         if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
             container_engine_cmd tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
             container_engine_cmd push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
         else
+            container_engine_cmd push "${IMAGE}:${IMAGE_TAG}"
             container_engine_cmd push "${IMAGE}:qa"
         fi
     fi


### PR DESCRIPTION
It has been observed  that the `build_deploy` script is set up so that when the SC build Job runs, it write a new image over the original `image_tag` on which the commit is based. 

This update fixes that issue. 
