### PR TITLE
Add image param to frontend config

### DIFF
--- a/deployment/deploy.yml
+++ b/deployment/deploy.yml
@@ -47,7 +47,7 @@ objects:
                 topologyKey: kubernetes.io/hostname
               weight: 99
         containers:
-        - image: quay.io/redhat-services-prod/hcc-pipeline-tenant/payload-tracker-frontend:${IMAGE_TAG}
+        - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 10
@@ -136,3 +136,7 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
+- description: Image
+  name: IMAGE
+  required: true
+  value: quay.io/redhat-services-prod/rh-platform-experien-tenant/payload-tracker-frontend


### PR DESCRIPTION
### Description

We are currently using cloudservices image, which is outdated and should no longer be used. This PR changes that by introducing param to change the image and by default let's use konflux prod image.

## Summary by Sourcery

Modify frontend deployment configuration to support configurable container image

New Features:
- Add new IMAGE parameter to deployment configuration with a default value for the Konflux production image

Enhancements:
- Introduce a flexible image parameter in the deployment configuration to allow easy image specification

Deployment:
- Update deployment template to use a parameterized image source instead of a hardcoded image