### PR TITLE
chore: configure renovate to only run on master branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,7 @@
 {
-  "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
-  ],
-  "ignorePaths": [
-    ".pre-commit-config.yaml"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "baseBranches": ["master"],
   "tekton": {
-    "enabled": true,
-    "packageRules": [
-      {
-        "matchUpdateTypes": [
-          "digest"
-        ],
-        "platformAutomerge": true,
-        "automerge": true
-      }
-    ]
+    "schedule": ["at any time"]
   }
 }


### PR DESCRIPTION
Currently, mintmaker will try to update all onboarded components but this is unnecessary for SC branches and just clutters the repo PR list. Only allowing renovate to run on main/master should help.